### PR TITLE
SafetyNet bypass

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char proc_cmdline[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", proc_cmdline);
 	return 0;
 }
 
@@ -23,6 +26,23 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+	/* SafetyNet bypass: show androidboot.verifiedbootstate=green */
+	char *a1, *a2;
+
+	a1 = strstr(saved_command_line, "androidboot.verifiedbootstate=");
+	if (a1) {
+		a1 = strchr(a1, '=');
+		a2 = strchr(a1, ' ');
+		if (!a2) /* last argument on the cmdline */
+			a2 = "";
+
+		scnprintf(proc_cmdline, COMMAND_LINE_SIZE, "%.*sgreen%s",
+			  (int)(a1 - saved_command_line + 1),
+			  saved_command_line, a2);
+	} else {
+		strncpy(proc_cmdline, saved_command_line, COMMAND_LINE_SIZE);
+	}
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
SafetyNet bypass: Show androidboot.verifiedbootstate=green

@Moyster 

UPD: This also breaks OCM